### PR TITLE
Add SQL query to find Wikistats page redirects

### DIFF
--- a/IP_addresses_or_ranges_blocked_currently.sql
+++ b/IP_addresses_or_ranges_blocked_currently.sql
@@ -1,0 +1,10 @@
+-- This query looks at the ipblocks table from the MediaWiki Permissions database
+-- The ipblocks table stores all blocked IP addresses in a hashed format
+-- ipb_range_start and ipb_range_end are TINYBLOB fields that store the blocked IP range
+-- ipb_expiry is a DATETIME field that indicates when the block expires
+
+SELECT ipb_range_start, ipb_range_end, ipb_expiry  
+FROM ipblocks  
+WHERE ipb_range_start IS NOT NULL  -- Only get entries that have a range start
+  AND ipb_range_end IS NOT NULL    -- Only get entries that have a range end
+  AND (ipb_expiry IS NULL OR ipb_expiry > NOW());  -- Only get active blocks - ipb_expiry is often set to "infinity" (NULL) by default

--- a/redirect_to_Wikistats_where_possible.sql
+++ b/redirect_to_Wikistats_where_possible.sql
@@ -1,0 +1,13 @@
+-- This query finds redirects to Wikistats pages
+-- I'm using the 'redirect' table to find these
+
+SELECT rd_from, rd_title, rd_namespace   -- these are the columns i need
+FROM redirect   -- looking in the redirect table
+WHERE
+  -- find anything with Wikistats in the name
+  rd_title LIKE '%Wikistats%'
+;  -- don't forget the semicolon!
+
+-- The rd_from is the page ID where the redirect comes from
+-- rd_title is where it goes to
+-- rd_namespace tells what type of page it is


### PR DESCRIPTION
The redirect_to_Wikistats_where_possible.sql file contains a query which searches the redirect table to find any pages that redirect to something with "Wikistats" in the name.

What my query does:
Looks in the redirect table
Finds pages that redirect to Wikistats pages
Shows the page ID, title, and namespace.

The IP_addresses_or_ranges_blocked_currently.sql contains a query which searches the ipblock table to find the blocked ip ranges the query selects only the blocked ip whose ipb_expiry is NULL or greater than the current time and date.

What my query does:
Looks in the ipblocks table
Finds the blocked ip ranges which are active
Shows the ipb_range_start,ipb_range_end and ipb_expiry.