### PR TITLE
Added Number of editors by user edit bucket,Number of unique user by …

### DIFF
--- a/Number_of_editors_by_user_edit_bucket.sql
+++ b/Number_of_editors_by_user_edit_bucket.sql
@@ -1,0 +1,17 @@
+-- Counting the number of actors in different contribution buckets
+SELECT COUNT(*), bucket 
+FROM (
+    -- Subquery: Categorizing actors based on the number of revisions they made
+    SELECT rev_actor,
+        CASE 
+            WHEN COUNT(rev_id) = 0 THEN '0'               -- No revisions
+            WHEN COUNT(rev_id) BETWEEN 1 AND 5 THEN '1-5' -- Between 1 and 5 revisions
+            WHEN COUNT(rev_id) BETWEEN 6 AND 99 THEN '6-99' -- Between 6 and 99 revisions
+            WHEN COUNT(rev_id) BETWEEN 100 AND 999 THEN '100-999' -- Between 100 and 999 revisions
+            WHEN COUNT(rev_id) BETWEEN 1000 AND 4999 THEN '1000-4999' -- Between 1000 and 4999 revisions
+            ELSE '5000+' -- More than 5000 revisions
+        END AS bucket
+    FROM revision
+    GROUP BY rev_actor -- Grouping by actor to count their revisions
+) AS sub_query
+GROUP BY bucket; -- Counting the number of actors in each bucket

--- a/Number_of_editors_by_user_edit_bucket.sql
+++ b/Number_of_editors_by_user_edit_bucket.sql
@@ -1,8 +1,9 @@
 -- Counting the number of actors in different contribution buckets
-SELECT COUNT(*), bucket 
-FROM (
-    -- Subquery: Categorizing actors based on the number of revisions they made
-    SELECT rev_actor,
+WITH revision_buckets AS (  --A CTE using WITH
+    SELECT COUNT(*), bucket 
+    FROM (
+        -- Subquery: Categorizing actors based on the number of revisions they made
+        SELECT rev_actor,
         CASE 
             WHEN COUNT(rev_id) = 0 THEN '0'               -- No revisions
             WHEN COUNT(rev_id) BETWEEN 1 AND 5 THEN '1-5' -- Between 1 and 5 revisions
@@ -11,7 +12,13 @@ FROM (
             WHEN COUNT(rev_id) BETWEEN 1000 AND 4999 THEN '1000-4999' -- Between 1000 and 4999 revisions
             ELSE '5000+' -- More than 5000 revisions
         END AS bucket
-    FROM revision
-    GROUP BY rev_actor -- Grouping by actor to count their revisions
-) AS sub_query
-GROUP BY bucket; -- Counting the number of actors in each bucket
+        FROM revision
+        GROUP BY rev_actor -- Grouping by actor to count their revisions
+    )
+
+SELECT 
+    bucket,
+    COUNT(*) AS number_of_editors   -- Counting the number of actors in each bucket
+FROM revision_buckets
+GROUP BY bucket
+ORDER BY bucket;

--- a/Number_of_unique_user_by_user_right_currently.sql
+++ b/Number_of_unique_user_by_user_right_currently.sql
@@ -1,0 +1,8 @@
+-- Number of unique user by user right currently
+SELECT ug_group, 
+       COUNT(DISTINCT ug_user) AS unique_users  -- Count distinct users in each group
+FROM user_groups  -- From the 'user_groups' table
+WHERE ug_group IN ('autoconfirmed', 'rollback', 'sysop', 'bureaucrat', 'checkuser', 'bot')  
+-- Filter only for specific user groups
+GROUP BY ug_group  -- Group by user group to count users per group
+ORDER BY unique_users DESC;  -- Sort results in descending order based on unique user count


### PR DESCRIPTION
metric : Number of editors by user edit bucket
First, the inner query processes each contributor (rev_actor) by counting how many revisions (rev_id) they have made. Based on this count, the contributor is placed into a specific bucket:
"0" → No revisions
"1-5" → Between 1 and 5 revisions
"6-99" → Between 6 and 99 revisions
"100-999" → Between 100 and 999 revisions
"1000-4999" → Between 1000 and 4999 revisions
"5000+" → More than 5000 revisions
The outer query then counts how many contributors are in each bucket and groups the results accordingly.

metric :Number of unique user by user right currently
It selects user groups (ug_group) and counts unique users (ug_user) in each group. The COUNT(DISTINCT ug_user) ensures that each user is counted only once per group.
It filters the results to include only specific user groups, like:
autoconfirmed – Regular users with basic permissions.
rollback – Users who can quickly revert edits.
sysop – Administrators with higher control.
bureaucrat – Users who can promote others to higher roles.
checkuser – Users with access to IP-related data for moderation.
bot – Automated accounts performing repetitive tasks.
It then groups the data by user group so that the count of unique users is calculated for each group separately.
Finally, it sorts the results in descending order, showing the groups with the highest number of users first.