### PR TITLE
Average size of an edit by edit count bucket

### DIFF
--- a/avg_size_of_edit.sql
+++ b/avg_size_of_edit.sql
@@ -1,11 +1,19 @@
 SELECT
+  CASE
+    WHEN user_edits.edit_count BETWEEN 1 AND 10 THEN '1–10'
+    WHEN user_edits.edit_count BETWEEN 11 AND 50 THEN '11–50'
+    WHEN user_edits.edit_count BETWEEN 51 AND 100 THEN '51–100'
+    WHEN user_edits.edit_count BETWEEN 101 AND 500 THEN '101–500'
+    WHEN user_edits.edit_count BETWEEN 501 AND 1000 THEN '501–1000'
+    ELSE '1001+'
+  END AS edit_count_bucket,
   AVG(ABS(CAST(r.rev_len AS SIGNED) - CAST(p.rev_len AS SIGNED))) AS avg_edit_size
-FROM (revision r
+FROM revision r
 JOIN revision p ON r.rev_parent_id = p.rev_id
 JOIN (
-  SELECT rev_actor, COUNT(*) AS edit_count
-  FROM revision     # number of edits done by user
+  SELECT rev_actor, COUNT(*) AS edit_count   # number of edits done by user
+  FROM revision
   GROUP BY rev_actor
-) AS user_edits ON r.rev_actor = user_edits.rev_actor)
-where user_edits.edit_count between 11 and 50    # we can change range of edits 
+) AS user_edits ON r.rev_actor = user_edits.rev_actor
+GROUP BY edit_count_bucket
 ;

--- a/avg_size_of_edit.sql
+++ b/avg_size_of_edit.sql
@@ -1,0 +1,11 @@
+SELECT
+  AVG(ABS(CAST(r.rev_len AS SIGNED) - CAST(p.rev_len AS SIGNED))) AS avg_edit_size
+FROM (revision r
+JOIN revision p ON r.rev_parent_id = p.rev_id
+JOIN (
+  SELECT rev_actor, COUNT(*) AS edit_count
+  FROM revision     # number of edits done by user
+  GROUP BY rev_actor
+) AS user_edits ON r.rev_actor = user_edits.rev_actor)
+where user_edits.edit_count between 11 and 50    # we can change range of edits 
+;


### PR DESCRIPTION
This query finds the average amount of content changed in edits (in bytes) . It compares each revision to its previous version, calculates how much the size changed (ignoring whether it was added or removed), and averages that value. You can change the range in the WHERE clause to target different groups of users 